### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "illuminate/support": "^11.0|^12.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
         "laravel/nova": "^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
Adds `^13.0` to illuminate/* package constraints to support Laravel 13.